### PR TITLE
Include a system attribute for UIs in the profile importer

### DIFF
--- a/app/lib/ca/ConfigurationExporter.php
+++ b/app/lib/ca/ConfigurationExporter.php
@@ -595,9 +595,7 @@ final class ConfigurationExporter {
 
 			$vo_ui->setAttribute("type", $vs_type);
 
-			if(!$qr_uis->get("is_system_ui")){
-				$vo_ui->setAttribute("system", '0');
-			}
+			$vo_ui->setAttribute("system", $qr_uis->get("is_system_ui"));
 
 			// labels
 			$vo_labels = $this->opo_dom->createElement("labels");

--- a/app/lib/ca/ConfigurationExporter.php
+++ b/app/lib/ca/ConfigurationExporter.php
@@ -595,6 +595,10 @@ final class ConfigurationExporter {
 
 			$vo_ui->setAttribute("type", $vs_type);
 
+			if(!$qr_uis->get("is_system_ui")){
+				$vo_ui->setAttribute("system", '0');
+			}
+
 			// labels
 			$vo_labels = $this->opo_dom->createElement("labels");
 			$qr_ui_labels = $this->opo_db->query("SELECT * FROM ca_editor_ui_labels WHERE ui_id=?",$qr_uis->get("ui_id"));

--- a/install/inc/Installer.php
+++ b/install/inc/Installer.php
@@ -782,6 +782,8 @@ class Installer {
 				return false;
 			}
 
+			// Existing profiles will probably not have this attribute set, so only make the UI a non-system if it is explicitly '0'
+			$vb_system = self::getAttribute($vo_ui, "system") !== '0';
 			// model instance of UI type
 			$t_instance = $vo_dm->getInstanceByTableNum($vn_type);
 
@@ -791,7 +793,7 @@ class Installer {
 			$t_ui = $t_ui ? $t_ui : new ca_editor_uis();
 			$t_ui->setMode(ACCESS_WRITE);
 			$t_ui->set('user_id', null);
-			$t_ui->set('is_system_ui', 1);
+			$t_ui->set('is_system_ui', $vb_system);
 			$t_ui->set('editor_code', $vs_ui_code);
 			$t_ui->set('editor_type', $vn_type);
 			if($t_ui->getPrimaryKey()){

--- a/install/profiles/xml/profile.xsd
+++ b/install/profiles/xml/profile.xsd
@@ -711,6 +711,7 @@
                   </xs:sequence>
                   <xs:attribute name="code" type="codeType" use="required"/>
                   <xs:attribute name="type" type="xs:string" use="required"/>
+                  <xs:attribute name="system" type="booleanType" use="optional"/>
                 </xs:complexType>
 
                 <!-- ui screen idnos must be unique inside a UI -->


### PR DESCRIPTION
Make it possible to store the 'is_system_ui' property of user interfaces
