### PR TITLE
Support https protocol by detection.

### DIFF
--- a/app/conf/assets.conf
+++ b/app/conf/assets.conf
@@ -125,7 +125,7 @@ packages = {
 	openlayers = {
 		maps = OpenLayers.js,
 		mobile = OpenLayers.mobile.js,
-		stamen = //stamen-maps.a.ssl.fastly.net/js/tile.stamen.js
+		stamen = https://stamen-maps.a.ssl.fastly.net/js/tile.stamen.js
 	},
 	# -----------------------
 	timelinejs = {

--- a/app/conf/assets.conf
+++ b/app/conf/assets.conf
@@ -125,7 +125,7 @@ packages = {
 	openlayers = {
 		maps = OpenLayers.js,
 		mobile = OpenLayers.mobile.js,
-		stamen = http://maps.stamen.com/js/tile.stamen.js?v1.1.3
+		stamen = //stamen-maps.a.ssl.fastly.net/js/tile.stamen.js
 	},
 	# -----------------------
 	timelinejs = {

--- a/app/conf/global.conf
+++ b/app/conf/global.conf
@@ -58,8 +58,8 @@ ca_lib_dir =  __CA_LIB_DIR__
 ca_models_dir = __CA_MODELS_DIR__
 
 # You MUST change these next three entries to match your web setup.
-site_protocol = http
-site_hostname =__CA_SITE_HOSTNAME__
+site_protocol = __CA_SITE_PROTOCOL__
+site_hostname = __CA_SITE_HOSTNAME__
 site_host = <site_protocol>://<site_hostname>
 
 # Leave 'ca_url_root' BLANK if the CollectiveAccess directory is the web server root.

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -219,6 +219,15 @@ if (!defined("__CA_SITE_HOSTNAME__")) {
 	define("__CA_SITE_HOSTNAME__", isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '');
 }
 
+#
+# __CA_SITE_HOSTNAME__ = the protocol your system should be accessed with
+#
+#		The default value is based on the URL being used to access the site.  To force a protocol, set it explicitly.
+#
+if (!defined("__CA_SITE_PROTOCOL__")) {
+	define("__CA_SITE_PROTOCOL__", isset($_SERVER['HTTPS']) ? 'https' : 'http');
+}
+
 # --------------------------------------------------------------------------------------------
 # IT IS VERY UNLIKELY THAT YOU WILL NEED TO CHANGE ANYTHING UNDER THIS LINE
 # --------------------------------------------------------------------------------------------

--- a/setup.php-dist
+++ b/setup.php-dist
@@ -220,7 +220,7 @@ if (!defined("__CA_SITE_HOSTNAME__")) {
 }
 
 #
-# __CA_SITE_HOSTNAME__ = the protocol your system should be accessed with
+# __CA_SITE_PROTOCOL__ = the protocol your system should be accessed with
 #
 #		The default value is based on the URL being used to access the site.  To force a protocol, set it explicitly.
 #


### PR DESCRIPTION
Previously the protocol was assumed to be plain HTTP, and a change to global.conf was required to support HTTPS.

This change detects the protocol used for the request and uses that as the base application protocol. This is similar to the way the hostname is detected.

The "other way" is to redirect HTTP->HTTPS but I don't see why port 80 should even be open for this internal system. We can have that discussion but either way, it shouldn't be constantly bouncing back to HTTP and then back to HTTPS, especially when the requests that seem to do this are around the login process, where passwords are involved, i.e. exactly when you don't want to be dropping out of HTTPS.

On the staging and uat servers, I have hacked the current deployment to change global.conf to hardcoded "https" instead of "http".
