### PR TITLE
RWAHS-167 Fix search query builder condition switch issue

### DIFF
--- a/themes/default/views/find/Search/search_controls_html.php
+++ b/themes/default/views/find/Search/search_controls_html.php
@@ -268,7 +268,9 @@
 			'afterDeleteRule.queryBuilder',
 			'afterUpdateRuleValue.queryBuilder',
 			'afterUpdateRuleFilter.queryBuilder',
-			'afterUpdateRuleOperator.queryBuilder'
+			'afterUpdateRuleOperator.queryBuilder',
+			'afterUpdateGroupCondition.queryBuilder',
+			'afterSetFilters.queryBuilder'
 		].join(' ');
 	}
 


### PR DESCRIPTION
- Some events were not causing the query string to update, which resulted
  in the result of running the query not being as intended (e.g. `x AND y`
  instead of `x OR y`).
