### PR TITLE
RWAHS-155 Fix issue with query builder fields as selects.

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -563,7 +563,7 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 		// Use the relevant input field type and operators based on type.
 		$va_result['operators'] = $va_operators_by_type[$va_result['type']];
 		// Process list types and use a text field for non-list types.
-		if (in_array($vn_display_type, array( DT_SELECT, DT_LIST, DT_LIST_MULTIPLE, DT_CHECKBOXES, DT_RADIO_BUTTONS ))) {
+		if (in_array($vn_display_type, array( DT_SELECT, DT_LIST, DT_LIST_MULTIPLE, DT_CHECKBOXES, DT_RADIO_BUTTONS ), true)) {
 			if (!$va_select_options) {
 				$va_select_options = array();
 				$t_list = new ca_lists();


### PR DESCRIPTION
- The `in_array` function takes a third argument, which sets the
  comparison to `strict` mode, i.e. `===` instead of `==`.
- Previously, `strict` was not passed, so non-strict comparison
  was being used, which equated `0` to an empty string or `null`.
- The value of the constant `DT_SELECT` is `0`, therefore it
  was the default field type.
- This forces the use of `strict` comparisons, which means that
  `DT_SELECT` is no longer the same as nothing.
