### PR TITLE
RWAHS-245 Fix issues with broken operators

### DIFF
--- a/app/conf/search_query_builder.conf
+++ b/app/conf/search_query_builder.conf
@@ -8,9 +8,12 @@ query_builder_enabled = 0
 # Global config for the query builder.  See http://querybuilder.js.org/#usage for available settings.
 query_builder_global_options = {}
 
+# Operators to provide per filter input type.  Note that `contains`, `not_contains`, `ends_with`, `not_ends_with` are
+# omitted from `string`, only because they are not supported by the search engine.  The query builder and the query
+# translator both correctly handle these operators.
 query_builder_operators = {
 	select = [ equal, not_equal, is_empty, is_not_empty ],
-	string = [ equal, not_equal, in, not_in, begins_with, not_begins_with, contains, not_contains, ends_with, not_ends_with, is_empty, is_not_empty ],
+	string = [ equal, not_equal, begins_with, not_begins_with, is_empty, is_not_empty ],
 	integer = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],
 	double = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],
 	date = [ equal, not_equal, between, not_between, is_empty, is_not_empty ],

--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -499,7 +499,8 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 		$va_select_options = null;
 		$va_result = array(
 			'id' => $vs_name,
-			'label' => $pa_bundle['label']
+			'label' => $pa_bundle['label'],
+			'type' => 'string'
 		);
 		if ($va_field_info) {
 			// Get the list code and display type for further processing below.
@@ -528,8 +529,6 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 				case FT_HISTORIC_DATETIME:
 					$va_result['type'] = 'datetime';
 					break;
-				default:
-					$va_result['type'] = 'string';
 			}
 		} elseif (in_array($vs_name_no_table, $va_element_codes)) {
 			$t_element = ca_metadata_elements::getInstance($vs_name_no_table);
@@ -553,9 +552,6 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 						break;
 					case __CA_ATTRIBUTE_VALUE_TIMECODE__:
 						$va_result['type'] = 'time';
-						break;
-					default:
-						$va_result['type'] = 'string';
 						break;
 				}
 			}


### PR DESCRIPTION
- Starts with and contains (and their negations) are not supported by the CA search engine.
- When using wildcards, they must appear outside the quoted value, i.e. `field:"value"*` and not `field:"value*"`.
