### PR TITLE
RWAHS-201 Collapsible displays

### DIFF
--- a/app/helpers/navigationHelpers.php
+++ b/app/helpers/navigationHelpers.php
@@ -64,6 +64,9 @@
  	define('__CA_NAV_BUTTON_MAKE_PRIMARY__', 25);
  	define('__CA_NAV_BUTTON_UPDATE__', 26);
  	define('__CA_NAV_BUTTON_PDF_SMALL__', 27);
+	define('__CA_NAV_BUTTON_COLLAPSE__', 28);
+	define('__CA_NAV_BUTTON_EXPAND__', 29);
+	define('__CA_NAV_BUTTON_PDF__', 30);
  		
  	define('__CA_NAV_BUTTON_ICON_POS_LEFT__', 0);
  	define('__CA_NAV_BUTTON_ICON_POS_RIGHT__', 1);
@@ -630,9 +633,11 @@
 				break;
 			case __CA_NAV_BUTTON_COLLAPSE__:
 				$vs_img_name = 'glyphicons_191_circle_minus';
+				$vs_classname = 'collapse';
 				break;
 			case __CA_NAV_BUTTON_EXPAND__:
 				$vs_img_name = 'glyphicons_190_circle_plus';
+				$vs_classname = 'expand';
 				break;					
 			case __CA_NAV_BUTTON_COMMIT__:
 				$vs_img_name = 'glyphicons_193_circle_ok';

--- a/themes/default/css/base.css
+++ b/themes/default/css/base.css
@@ -1263,10 +1263,18 @@ div.hint {
 	font-size: 11px;
 	display:inline;
 }
-#summary #printButton{
+#summary #printButton {
     float:right;
-    width:30px;
-    margin:0px 5px 5px 10px;
+    margin:0 5px 5px 10px;
+}
+#summary #toggleCollapsedButton {
+    float:right;
+    margin:0 5px 5px 0;
+}
+#summary #toggleCollapsedButton .form-button {
+    display: inline;
+    margin: 0;
+    padding: 0;
 }
 #summary .unit{
     margin-bottom:10px;

--- a/themes/default/views/editor/objects/summary_html.php
+++ b/themes/default/views/editor/objects/summary_html.php
@@ -38,6 +38,12 @@
 <?php
 	if ($vs_display_select_html = $t_display->getBundleDisplaysAsHTMLSelect('display_id', array('onchange' => 'jQuery("#caSummaryDisplaySelectorForm").submit();',  'class' => 'searchFormSelector'), array('table' => $t_item->tableNum(), 'value' => $t_display->getPrimaryKey(), 'access' => __CA_BUNDLE_DISPLAY_READ_ACCESS__, 'user_id' => $this->request->getUserID(), 'restrictToTypes' => array($t_item->getTypeID())))) {
 ?>
+		<div id="toggleCollapsedButton">
+			<a href="#">
+				<?php print caNavButton($this->request, __CA_NAV_BUTTON_COLLAPSE__); ?>
+				<?php print caNavButton($this->request, __CA_NAV_BUTTON_EXPAND__); ?>
+			</a>
+		</div>
 		<div id="printButton">
 			<a href="<?php print caNavUrl($this->request, $this->request->getModulePath(), $this->request->getController(), "PrintSummary", array("object_id" => $t_item->getPrimaryKey()))?>">
 				<?php print caNavIcon($this->request, __CA_NAV_BUTTON_PDF__); ?>
@@ -122,5 +128,27 @@
 	</table>
 </div><!-- end summary -->
 <?php
-		TooltipManager::add('#printButton', _t("Download Summary as PDF"));
-		TooltipManager::add('a.downloadMediaContainer', _t("Download Media"));
+TooltipManager::add('#printButton', _t("Download Summary as PDF"));
+TooltipManager::add('#toggleCollapsedButton .collapse', _t("Hide empty-valued fields"));
+TooltipManager::add('#toggleCollapsedButton .expand', _t("Show empty-valued fields"));
+TooltipManager::add('a.downloadMediaContainer', _t("Download Media"));
+?>
+<script>
+(function () {
+	var setCollapsed, collapsed, jar;
+	jar = jQuery.cookieJar('caCookieJar');
+	setCollapsed = function (value) {
+		collapsed = value;
+		jQuery('.unit.notDefined')[collapsed ? 'slideUp' : 'slideDown']();
+		jQuery('#toggleCollapsedButton .collapse').toggle(!collapsed);
+		jQuery('#toggleCollapsedButton .expand').toggle(collapsed);
+		jar.set('DisplayModeForNotDefined', collapsed ? 'collapsed' : 'expanded');
+	};
+	jQuery(function () {
+		jQuery('#toggleCollapsedButton > a').on('click', function () {
+			setCollapsed(!collapsed);
+		});
+		setCollapsed(jar.get('DisplayModeForNotDefined') !== 'expanded'); // Default to collapsed
+	});
+}());
+</script>


### PR DESCRIPTION
- Add a button that toggles displays between showing and hiding hidden fields.
- Default to collapsed (empty values are hidden).
- Store collapsed/expanded state in a cookie.
- Store a single cookie for all displays, i.e. the initial state of any display will be the same as the final state of the previously visited display.
