### PR TITLE
RWAHS-290 Bugfix for "missing argument" warnings

### DIFF
--- a/app/helpers/navigationHelpers.php
+++ b/app/helpers/navigationHelpers.php
@@ -633,12 +633,10 @@
 				break;
 			case __CA_NAV_BUTTON_COLLAPSE__:
 				$vs_img_name = 'glyphicons_191_circle_minus';
-				$vs_classname = 'collapse';
 				break;
 			case __CA_NAV_BUTTON_EXPAND__:
 				$vs_img_name = 'glyphicons_190_circle_plus';
-				$vs_classname = 'expand';
-				break;					
+				break;
 			case __CA_NAV_BUTTON_COMMIT__:
 				$vs_img_name = 'glyphicons_193_circle_ok';
 				break;	

--- a/themes/default/views/editor/objects/summary_html.php
+++ b/themes/default/views/editor/objects/summary_html.php
@@ -40,8 +40,8 @@
 ?>
 		<div id="toggleCollapsedButton">
 			<a href="#">
-				<?php print caNavButton($this->request, __CA_NAV_BUTTON_COLLAPSE__); ?>
-				<?php print caNavButton($this->request, __CA_NAV_BUTTON_EXPAND__); ?>
+				<span class="collapse"><?php print caNavIcon($this->request, __CA_NAV_BUTTON_COLLAPSE__); ?></span>
+				<span class="expand"><?php print caNavIcon($this->request, __CA_NAV_BUTTON_EXPAND__); ?></span>
 			</a>
 		</div>
 		<div id="printButton">


### PR DESCRIPTION
- Use `caNavIcon` instead of `caNavButton`, and add `<span>` element wrappers.
- Revert previously added (now unnecessary) class names.
