### PR TITLE
NOJIRA - Fix trimming of original value in `transformValuesUsingWorksheet`

### DIFF
--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -848,7 +848,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 					if ($va_options && is_array($va_options) && isset($va_options['transformValuesUsingWorksheet']) && $va_options['transformValuesUsingWorksheet']) {
 						if ($o_opt_sheet = $o_excel->getSheetByName($va_options['transformValuesUsingWorksheet'])) {
 							foreach ($o_opt_sheet->getRowIterator() as $o_sheet_row) {
-								if (!trim($vs_original_value = mb_strtolower((string)$o_opt_sheet->getCellByColumnAndRow(0, $o_sheet_row->getRowIndex())))) { continue; }
+								if (!$vs_original_value = trim(mb_strtolower((string)$o_opt_sheet->getCellByColumnAndRow(0, $o_sheet_row->getRowIndex())))) { continue; }
 								$vs_replacement_value = trim((string)$o_opt_sheet->getCellByColumnAndRow(1, $o_sheet_row->getRowIndex()));
 								$va_original_values[] = $vs_original_value;
 								$va_replacement_values[] = $vs_replacement_value;
@@ -860,7 +860,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 						$va_replacement_values = preg_split("![\n\r]{1}!", (string)$o_replacement_values->getValue());
 						array_walk($va_replacement_values, function(&$v) { $v = trim($v); });
 					}
-						
+
 					// Strip excess space from keys
 					if (is_array($va_options)) {
 						foreach($va_options as $vs_k => $vm_v) {


### PR DESCRIPTION
- `ca_data_importers::replaceValue()` trims the value before looking it up, so this should work around issues with inconsistent leading and trailing whitespace in source and destination data.
