### PR TITLE
Remove variable that was used only once

### DIFF
--- a/themes/default/views/editor/objects/screen_html.php
+++ b/themes/default/views/editor/objects/screen_html.php
@@ -122,8 +122,7 @@
 					}
 					$suffix.val(seriesAndParts[1]);
 				}
-				var $numeric = jQuery('#idno_accession_year,#idno_accession_number,.idno_accession_series');
-				$numeric.on('keypress', function (evt) {
+				jQuery('#idno_accession_year,#idno_accession_number,.idno_accession_series').on('keypress', function (evt) {
 					if (
 						// Space
 					evt.which === 32 ||


### PR DESCRIPTION
Saving variable ;) - I'd tried to just select the two existing fields and then add the `$series` to the array, but tried `push()` and `append()` both of which were wrong. I've since discovered that I could have used `add()`, but horses and stable doors.
