### PR TITLE
RWAHS-441 Use preference for resetting searches in custom search menu items

### DIFF
--- a/app/plugins/rwahsNavigation/rwahsNavigationPlugin.php
+++ b/app/plugins/rwahsNavigation/rwahsNavigationPlugin.php
@@ -185,7 +185,8 @@ class rwahsNavigationPlugin extends BaseApplicationPlugin {
                     'parameters' => array(
                         'type_id' => 'string:' . $vo_type->getPrimaryKey(),
                         'form_id' => 'string:' . $vn_form_id,
-                        'display_id' => 'string:' . $vn_bundle_display_id
+                        'display_id' => 'string:' . $vn_bundle_display_id,
+                        'reset' => 'preference:persistent_search'
                     )
                 );
             }

--- a/tests/plugins/rwahsNavigation/RwahsNavigationPluginIntegrationTest.php
+++ b/tests/plugins/rwahsNavigation/RwahsNavigationPluginIntegrationTest.php
@@ -258,7 +258,8 @@ class RwahsNavigationPluginIntegrationTest extends AbstractPluginIntegrationTest
 			array(
 				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type1')->getPrimaryKey(),
 				'form_id' => 'string:' . $this->_retrieveCreatedInstance('ca_search_forms', 'type1_search')->getPrimaryKey(),
-				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey()
+				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey(),
+				'reset' => 'preference:persistent_search'
 			),
 			$va_nav_info['find']['navigation']['type1']['parameters'],
 			'The URL parameters of the first search shortcut are correct'
@@ -291,7 +292,8 @@ class RwahsNavigationPluginIntegrationTest extends AbstractPluginIntegrationTest
 			array(
 				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type2')->getPrimaryKey(),
 				'form_id' => 'string:' . $this->_retrieveCreatedInstance('ca_search_forms', 'type2_search')->getPrimaryKey(),
-				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey()
+				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey(),
+				'reset' => 'preference:persistent_search'
 			),
 			$va_nav_info['find']['navigation']['type2']['parameters'],
 			'The URL parameters of the second search menu shortcut are correct'
@@ -324,7 +326,8 @@ class RwahsNavigationPluginIntegrationTest extends AbstractPluginIntegrationTest
 			array(
 				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type3')->getPrimaryKey(),
 				'form_id' => 'string:' . $this->_retrieveCreatedInstance('ca_search_forms', 'type3_search')->getPrimaryKey(),
-				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey()
+				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey(),
+				'reset' => 'preference:persistent_search'
 			),
 			$va_nav_info['find']['navigation']['type3']['parameters'],
 			'The URL parameters of the third search shortcut are correct'


### PR DESCRIPTION
Previously the search url for library pointed to:

`index.php/find/SearchObjectsAdvanced/Index/type_id/27/form_id/8/display_id/3/`

Now with this fix the search points to:

`index.php/find/SearchObjectsAdvanced/Index/type_id/27/form_id/8/display_id/3/reset/save` with the preference set to _Retain previous search terms and results when performing a search or browse_ and points to:

`index.php/find/SearchObjectsAdvanced/Index/type_id/27/form_id/8/display_id/3/reset/clear` with the preference set to _Clear previous search terms when performing a new search or browse_
