### PR TITLE
Put object images on the right in multiple summary view

### DIFF
--- a/themes/default/css/local.css
+++ b/themes/default/css/local.css
@@ -1,0 +1,6 @@
+#logo img {
+	height: 100%;
+}
+.objectFullImageContainer {
+	float: right;
+}


### PR DESCRIPTION
Even if there is no image, it sticks a massive empty rectangle on the left. This change puts the image (and empty rectangle) on the right.

This is how it looks normally
![default](https://cloud.githubusercontent.com/assets/12571/16940944/a8f1737a-4dbf-11e6-9df0-7b77224c7147.png)

With this change
![imagesonright](https://cloud.githubusercontent.com/assets/12571/16940945/a9204f4c-4dbf-11e6-86a7-eb19651a6c1e.png)
