### PR TITLE
NOJIRA Support mapping to preferred labels using `attributes` in refineries

### DIFF
--- a/app/helpers/importHelpers.php
+++ b/app/helpers/importHelpers.php
@@ -788,11 +788,11 @@
 	
 						switch($ps_table) {
 							case 'ca_entities':
-								$va_val['preferred_labels'] = DataMigrationUtils::splitEntityName($vs_item, $pa_options);
+								if(!isset($va_val['preferred_labels'])) { $va_val['preferred_labels'] = DataMigrationUtils::splitEntityName($vs_item, $pa_options); }
 								if(!isset($va_val['idno'])) { $va_val['idno'] = $vs_item; }
 								break;
 							case 'ca_list_items':
-								$va_val['preferred_labels'] = array('name_singular' => str_replace("_", " ", $vs_item), 'name_plural' => str_replace("_", " ", $vs_item));
+								if(!isset($va_val['preferred_labels'])) { $va_val['preferred_labels'] = array('name_singular' => str_replace("_", " ", $vs_item), 'name_plural' => str_replace("_", " ", $vs_item)); }
 								$va_val['_list'] = $pa_options['list_id'];
 								if(!isset($va_val['idno'])) { $va_val['idno'] = $vs_item; }
 								break;
@@ -803,11 +803,11 @@
 							case 'ca_occurrences':
 							case 'ca_places':
 							case 'ca_objects':
-								$va_val['preferred_labels'] = array('name' => $vs_item);
+								if(!isset($va_val['preferred_labels'])) { $va_val['preferred_labels'] = array('name' => $vs_item); }
 								if(!isset($va_val['idno'])) { $va_val['idno'] = $vs_item; }
 								break;
 							case 'ca_object_lots':
-								$va_val['preferred_labels'] = array('name' => $vs_item);
+								if(!isset($va_val['preferred_labels'])) { $va_val['preferred_labels'] = array('name' => $vs_item); }
 								if(!isset($va_val['idno_stub'])) { $va_val['idno_stub'] = $vs_item; }
 								
 								if (isset($va_val['_status'])) {


### PR DESCRIPTION
- When using `{"matchOn":["idno"]}` we don't necessarily want the label to be the same as the generated `idno`
  - uses the same logic as is used for setting the `idno` of the record
  - This change makes it possible to define a `preferred_labels` key within `attributes` in the refinery parameters as follows:
  
  ``` json
  {
     "occurrenceType": "Conservation",
     "relationshipType": "conservation",
     "matchOn": [
         "idno"
     ],
     "attributes": {
         "ConservationDetails": "^Conservation",
         "ConservationDate": "^ConservationDate",
         "Conservator": "^ConservationBy",
         "preferred_labels":{
             "name": "^Accession_Full_ID conserved on ^ConservationDate"
         }
     }
  }
  ```
