### PR TITLE
Fix advanced search datepickers

### DIFF
--- a/app/conf/assets.conf
+++ b/app/conf/assets.conf
@@ -235,6 +235,10 @@ loadSets = {
 		ca/browsePanel, jquery/tools
 	],
 	
+	advancedsearch = [
+		jquery/moment, jquery/daterangepicker, jquery/daterangepickercss
+	],
+	
 	panel = [
 		ca/panel, jquery/tools
 	],

--- a/app/lib/ca/BaseAdvancedSearchController.php
+++ b/app/lib/ca/BaseAdvancedSearchController.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2010-2015 Whirl-i-Gig
+ * Copyright 2010-2016 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -59,6 +59,7 @@ class BaseAdvancedSearchController extends BaseRefineableSearchController {
 	public function Index($pa_options=null) {
 		$po_search = (isset($pa_options['search']) && $pa_options['search']) ? $pa_options['search'] : null;
 		parent::Index($pa_options);
+		AssetLoadManager::register('advancedsearch');
 		AssetLoadManager::register('browsable');	// need this to support browse panel when filtering/refining search results
 
 		// Get elements of result context
@@ -267,6 +268,8 @@ class BaseAdvancedSearchController extends BaseRefineableSearchController {
 	# Ajax
 	# -------------------------------------------------------
 	public function getAdvancedSearchForm($pb_render_view=null) {
+		AssetLoadManager::register('advancedsearch');
+		
 		$t_form = new ca_search_forms();
 		if (!($vn_form_id = $this->request->getParameter('form_id', pInteger))) {
 			if ((!($vn_form_id = $this->opo_result_context->getParameter('form_id'))) || (!$t_form->haveAccessToForm($this->request->getUserID(), __CA_SEARCH_FORM_READ_ACCESS__, $vn_form_id))) {


### PR DESCRIPTION
Backport fix from upstream for advanced searches with datepicker fields in advanced search form.
- Refine search and bulk (spreadsheet) editing are broken due to missing JS dependency.

https://github.com/collectiveaccess/providence/commit/b58f1c52e958d66bc826b1c782a3613652f8e3f1
https://github.com/collectiveaccess/providence/commit/c8fb0ef78949daf27eb172b934f5f7453b40ec25
