### PR TITLE
RWAHS-502 Search within containers

### DIFF
--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -1287,6 +1287,7 @@ class SearchIndexer extends SearchBase {
 		$va_attributes = $va_attributes ?: $pt_subject->getAttributesByElement($pm_element_code_or_id, array('row_id' => $pn_row_id));
 		$pn_subject_tablenum = $pt_subject->tableNum();
 		$vn_datatype = isset($pa_data['datatype']) ? $pa_data['datatype'] : ca_metadata_elements::getElementDatatype($pm_element_code_or_id);
+		$vn_element_id = is_numeric($pm_element_code_or_id) ? $pm_element_code_or_id : ca_metadata_elements::getElementID($pm_element_code_or_id);
 
 		switch($vn_datatype) {
 			case __CA_ATTRIBUTE_VALUE_CONTAINER__:
@@ -1294,7 +1295,6 @@ class SearchIndexer extends SearchBase {
 				if (sizeof($va_attributes)) {
 					foreach($va_attributes as $vo_attribute) {
 						// Index each element of the container via a recursive call.
-						$vn_element_id = is_numeric($pm_element_code_or_id) ? $pm_element_code_or_id : ca_metadata_elements::getElementID($pm_element_code_or_id);
 						$va_sub_element_ids = $this->opo_metadata_element->getElementsInSet($vn_element_id, true, array('idsOnly' => true));
 
 						foreach ($va_sub_element_ids as $vn_sub_element_id) {
@@ -1325,7 +1325,6 @@ class SearchIndexer extends SearchBase {
 			case __CA_ATTRIBUTE_VALUE_OBJECTLOTS__:
 				// We pull the preferred labels of list items for indexing here. We do so for all languages.
 				$va_tmp = array();
-				$vn_element_id = is_numeric($pm_element_code_or_id) ? $pm_element_code_or_id : ca_metadata_elements::getElementID($pm_element_code_or_id);
 
 				if (is_array($va_attributes) && sizeof($va_attributes)) {
 					foreach($va_attributes as $vo_attribute) {
@@ -1377,7 +1376,6 @@ class SearchIndexer extends SearchBase {
 				break;
 
 			default:
-				$vn_element_id = is_numeric($pm_element_code_or_id) ? $pm_element_code_or_id : ca_metadata_elements::getElementID($pm_element_code_or_id);
 				$va_attributes = $pt_subject->getAttributesByElement($pm_element_code_or_id, array('row_id' => $pn_row_id));
 				if (is_array($va_attributes) && sizeof($va_attributes) > 0) {
 					foreach($va_attributes as $vo_attribute) {

--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -1296,10 +1296,11 @@ class SearchIndexer extends SearchBase {
 					foreach($va_attributes as $vo_attribute) {
 						// Index each element of the container via a recursive call.
 						$va_sub_element_ids = $this->opo_metadata_element->getElementsInSet($vn_element_id, true, array('idsOnly' => true));
-
-						foreach ($va_sub_element_ids as $vn_sub_element_id) {
-							if ($vn_sub_element_id !== intval($vo_attribute->getElementID())) {
-								$this->_indexAttribute($pt_subject, $pn_row_id, $vn_sub_element_id, array_merge($pa_data, array( 'datatype' => ca_metadata_elements::getElementDatatype($vn_sub_element_id) )), array( $vo_attribute ));
+						if (is_array($va_sub_element_ids)) {
+							foreach ($va_sub_element_ids as $vn_sub_element_id) {
+								if ($vn_sub_element_id !== intval($vo_attribute->getElementID())) {
+									$this->_indexAttribute($pt_subject, $pn_row_id, $vn_sub_element_id, array_merge($pa_data, array( 'datatype' => ca_metadata_elements::getElementDatatype($vn_sub_element_id) )), array( $vo_attribute ));
+								}
 							}
 						}
 					}

--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -1330,7 +1330,7 @@ class SearchIndexer extends SearchBase {
 				if (is_array($va_attributes) && sizeof($va_attributes)) {
 					foreach($va_attributes as $vo_attribute) {
 						foreach($vo_attribute->getValues() as $vo_value) {
-							if (intval($vo_value->getElementID()) === $vn_element_id) {
+							if (intval($vo_value->getElementID()) === intval($vn_element_id)) {
 								$vs_value_to_index = $vo_value->getDisplayValue(array('idsOnly' => true));
 								$va_additional_indexing = $vo_value->getDataForSearchIndexing();
 								if(is_array($va_additional_indexing) && (sizeof($va_additional_indexing) > 0)) {
@@ -1380,7 +1380,7 @@ class SearchIndexer extends SearchBase {
 				if (is_array($va_attributes) && sizeof($va_attributes) > 0) {
 					foreach($va_attributes as $vo_attribute) {
 						foreach($vo_attribute->getValues() as $vo_value) {
-							if (intval($vo_value->getElementID()) === $vn_element_id) {
+							if (intval($vo_value->getElementID()) === intval($vn_element_id)) {
 								$vs_value_to_index = $vo_value->getDisplayValue();
 								$va_additional_indexing = $vo_value->getDataForSearchIndexing();
 								if (is_array($va_additional_indexing) && (sizeof($va_additional_indexing) > 0)) {

--- a/app/lib/core/Search/SearchIndexer.php
+++ b/app/lib/core/Search/SearchIndexer.php
@@ -1376,20 +1376,19 @@ class SearchIndexer extends SearchBase {
 				break;
 
 			default:
-				$va_attributes = $pt_subject->getAttributesByElement($pm_element_code_or_id, array('row_id' => $pn_row_id));
 				if (is_array($va_attributes) && sizeof($va_attributes) > 0) {
 					foreach($va_attributes as $vo_attribute) {
 						foreach($vo_attribute->getValues() as $vo_value) {
-							$vs_value_to_index = $vo_value->getDisplayValue();
-
-							$va_additional_indexing = $vo_value->getDataForSearchIndexing();
-							if(is_array($va_additional_indexing) && (sizeof($va_additional_indexing) > 0)) {
-								foreach($va_additional_indexing as $vs_additional_value) {
-									$vs_value_to_index .= " ; ".$vs_additional_value;
+							if (intval($vo_value->getElementID()) === $vn_element_id) {
+								$vs_value_to_index = $vo_value->getDisplayValue();
+								$va_additional_indexing = $vo_value->getDataForSearchIndexing();
+								if (is_array($va_additional_indexing) && (sizeof($va_additional_indexing) > 0)) {
+									foreach ($va_additional_indexing as $vs_additional_value) {
+										$vs_value_to_index .= " ; " . $vs_additional_value;
+									}
 								}
+								$this->opo_engine->indexField($pn_subject_tablenum, 'A'.$vn_element_id, $pn_row_id, $vs_value_to_index, $pa_data);
 							}
-
-							$this->opo_engine->indexField($pn_subject_tablenum, 'A'.$vn_element_id, $pn_row_id, $vs_value_to_index, $pa_data);
 						}
 					}
 				} else {


### PR DESCRIPTION
Fixes both issues relating to searching elements within containers:
- The query builder only lists containers themselves, not their children, which is where the actual data is.
- CA only indexes the ID for list elements nested under containers, not the text values.  (For "top-level" list elements, i.e. not in a container, the text value is indexed).
