### PR TITLE
Parse non parameterised search text

### DIFF
--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -274,7 +274,7 @@ var caUI = caUI || {};
 	 * Determine whether the given list of tokens is all words and whitespace.
 	 * @param {Array} tokens
 	 * @returns {boolean}
-     */
+	 */
 	isRawSearchText = function (tokens) {
 		var allWords = true;
 		$.each(tokens, function (i, token) {


### PR DESCRIPTION
Includes #33 so please merge that first.

Allows the user to type in `foo bar` and, when the query builder is open, that gets converted into the equivalent search query syntax: `(_fulltext:"foo bar")`.
