### PR TITLE
Expose `item_value` for dropdown searches

### DIFF
--- a/app/conf/search_query_builder.conf
+++ b/app/conf/search_query_builder.conf
@@ -31,6 +31,8 @@ query_builder_enabled_ca_collections = 1
 query_builder_enabled_ca_occurrences = 1
 query_builder_enabled_ca_storage_locations = 1
 query_builder_enabled_ca_loans = 1
+query_builder_enabled_ca_movements = 1
+query_builder_enabled_ca_object_representations = 1
 
 # Per-table list of filter names to move to the top of the query builder's list, in the order given.  Filters can come
 # from intrinsic fields, attributes or search access points.
@@ -103,6 +105,20 @@ query_builder_priority_ca_loans = [
 	ca_loans.status,
 	_fulltext
 ]
+query_builder_priority_ca_movements = [
+	ca_movements.idno,
+	ca_loan_labels.name,
+	ca_movements.type_id,
+	ca_movements.status,
+	_fulltext
+]
+query_builder_priority_ca_object_representations = [
+	ca_object_representations.idno,
+	ca_loan_labels.name,
+	ca_object_representations.type_id,
+	ca_object_representations.status,
+	_fulltext
+]
 
 # Per-table list of filter names to exclude from the query builder.  Filters can come from intrinsic fields, attributes
 # or search access points.
@@ -114,3 +130,19 @@ query_builder_exclude_ca_collections = []
 query_builder_exclude_ca_occurrences = []
 query_builder_exclude_ca_storage_locations = []
 query_builder_exclude_ca_loans = []
+query_builder_exclude_ca_object_representations = []
+query_builder_exclude_ca_movements = []
+
+# Specify which list fields should search by item value rather than idno.
+query_builder_list_fields_search_by_value = [
+	ca_objects.access,
+	ca_object_lots.access,
+	ca_entities.access,
+	ca_places.access,
+	ca_collections.access,
+	ca_occurrences.access,
+	ca_storage_locations.access,
+	ca_loans.access,
+	ca_movements.access,
+	ca_object_representations.access
+]

--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -516,6 +516,8 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 		$vs_table = $t_subject->tableName();
 		$va_priority = $vo_query_builder_config->get('query_builder_priority_' . $vs_table);
 		$va_operators_by_type = $vo_query_builder_config->get('query_builder_operators');
+		$va_list_fields_search_by_value = $vo_query_builder_config->get('query_builder_list_fields_search_by_value');
+		$vs_list_key_field = in_array($vs_name, $va_list_fields_search_by_value) ? 'item_value': 'idno';
 		$va_field_info = $t_subject->getFieldInfo($vs_name_no_table);
 		$vn_display_type = null;
 		$vs_list_code = null;
@@ -590,7 +592,7 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 				if (is_array($va_items)) {
 					foreach ($va_items as $va_item) {
 						foreach ($va_item as $va_item_details) {
-							$va_select_options[$va_item_details['idno']] = $va_item_details['name_singular'];
+							$va_select_options[$va_item_details[$vs_list_key_field]] = $va_item_details['name_singular'];
 						}
 					}
 				}


### PR DESCRIPTION
- Specify which fields search by `item_value` rather than idno
- Additionally enable query builder on movement and representation searches
