### PR TITLE
Fix empty queries query builder

### DIFF
--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -55,7 +55,7 @@ var caUI = caUI || {};
 	 * @returns {String}
 	 */
 	escapeValue = function (value) {
-		return value.replace(/([\-\+&\|!\(\)\{}\[\]\^"~\*\?:\\])/, '\\$1');
+		return value.replace(/([\-\+&\|!\(\)\{}\[\]\^"~\*\?:\\])/g, '\\$1');
 	};
 
 	/**

--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -81,7 +81,7 @@ var caUI = caUI || {};
 				case 'between':
 					return prefix + '[' + escapeValue(ruleSet.value[0]) + ' TO ' + escapeValue(ruleSet.value[1]) + ']';
 				case 'begins_with':
-					return prefix + '' + escapeValue(ruleSet.value) + '*';
+					return prefix + escapeValue(ruleSet.value) + '*';
 				case 'contains':
 					return prefix + '*"' + escapeValue(ruleSet.value) + '"*';
 				case 'ends_with':

--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -374,6 +374,8 @@ var caUI = caUI || {};
 					} else {
 						// Other types can be a (quoted or unquoted) word and/or suffix.
 						// Alternatively the word itself can be omitted, i.e. just a wildcard (`is_not_empty`).
+
+						// Disable wildcard prefix as CA doesn't support this kind of searching at the moment
 						wildcardPrefix = false;
 						word = isNextToken(tokens, TOKEN_WORD);
 						wildcardSuffix = isNextToken(tokens, TOKEN_WILDCARD);

--- a/assets/ca/ca.querytranslator.js
+++ b/assets/ca/ca.querytranslator.js
@@ -369,7 +369,7 @@ var caUI = caUI || {};
 							assertNextToken(tokens, TOKEN_RBRACKET);
 							assignOperatorAndValue(rule, false, negation);
 						} else {
-							throw 'Unexpected token value "' + tokenAfterBracket.value + '" for token of type "' + tokenAfterBracket.type + '", expected "BLANK".';
+							throw 'Unexpected token value "' + tokenAfterBracket.value + '" for token of type "' + tokenAfterBracket.type + '", expected "BLANK" or a range like "0 TO 100".';
 						}
 					} else {
 						// Other types can be a (quoted or unquoted) word and/or suffix.


### PR DESCRIPTION
Use `[BLANK]` for blank values in query builder ￼…
- Match everything with a value using `table.fieldname:*`
- Match blank values using `table.fieldname:[BLANK]`
- Fix `begins with` search by removing quotes around the term
- Change negation token from `-` to `!`
- Escape full string, not just first matching character
