### PR TITLE
RWAHS-596 Fix search by access point

### DIFF
--- a/app/lib/core/Search/Common/Parsers/LuceneSyntaxParserContext.php
+++ b/app/lib/core/Search/Common/Parsers/LuceneSyntaxParserContext.php
@@ -295,7 +295,7 @@ class LuceneSyntaxParserContext {
                             break;
 
                         default:
-                            throw new Zend_Search_Lucene('Boolean expression error. Unknown operator type.');
+                            throw new Zend_Search_Lucene_Exception('Boolean expression error. Unknown operator type.');
                     }
                 }
             }

--- a/app/lib/core/Search/SearchEngine.php
+++ b/app/lib/core/Search/SearchEngine.php
@@ -470,7 +470,7 @@ class SearchEngine extends SearchBase {
 	/**
 	 * @param $po_term - term to rewrite; must be Zend_Search_Lucene_Search_Query_Term object
 	 * @param $pb_sign - Zend boolean flag (true=and, null=or, false=not)
-	 * @return Zend_Search_Lucene_Search_Query_MultiTerm
+	 * @return Zend_Search_Lucene_Search_Query
 	 */
 	private function _rewriteTerm($po_term, $pb_sign) {
 		$vs_fld = $po_term->getTerm()->field;
@@ -521,7 +521,9 @@ class SearchEngine extends SearchBase {
 					}
 				}
 
-				return new Zend_Search_Lucene_Search_Query_MultiTerm($va_terms['terms'], $va_terms['signs']);
+				return sizeof($va_terms) === 1 ?
+					new Zend_Search_Lucene_Search_Query_Term($va_terms['terms'][0], $va_terms['signs'][0]) :
+					new Zend_Search_Lucene_Search_Query_MultiTerm($va_terms['terms'], $va_terms['signs']);
 			}
 		}
 		
@@ -531,15 +533,15 @@ class SearchEngine extends SearchBase {
 		if (in_array($va_tmp2[1], array('preferred_labels', 'nonpreferred_labels'))) {
 			if ($t_instance = $this->opo_datamodel->getInstanceByTableName($va_tmp2[0], true)) {
 				if (method_exists($t_instance, "getLabelTableName")) {
-					return new Zend_Search_Lucene_Search_Query_MultiTerm(
-						array(new Zend_Search_Lucene_Index_Term($po_term->getTerm()->text, $t_instance->getLabelTableName().'.'.((isset($va_tmp2[2]) && $va_tmp2[2]) ? $va_tmp2[2] : $t_instance->getLabelDisplayField()).($va_tmp[1] ? '/'.$va_tmp[1] : ''))),
-						array($pb_sign)
+					return new Zend_Search_Lucene_Search_Query_Term(
+						new Zend_Search_Lucene_Index_Term($po_term->getTerm()->text, $t_instance->getLabelTableName().'.'.((isset($va_tmp2[2]) && $va_tmp2[2]) ? $va_tmp2[2] : $t_instance->getLabelDisplayField()).($va_tmp[1] ? '/'.$va_tmp[1] : '')),
+						$pb_sign
 					);
 				}
 			}
 		}
 		
-		return new Zend_Search_Lucene_Search_Query_MultiTerm(array($po_term->getTerm()), array($pb_sign));
+		return new Zend_Search_Lucene_Search_Query_Term($po_term->getTerm(), $pb_sign);
 	}
 	# ------------------------------------------------------------------
 	/**


### PR DESCRIPTION
Fix issue with search by access points.
- Previously, an access point used in a search query would generate
  an array of `terms` and an array of `signs` that go with those `terms`,
  with the logical operator based on the definition of the access point 
  (`OR` by default).
- However this is incorrect, because the logical operator inside the
  access point was "leaking" out into the remainder of the query.  For
  example, if `ap` is an access point that consists attributes `x` and,
  `y`, and `z` is another attribute, then a search for 
  `ap:"foo" AND z:"bar"` would work as expected, but
  `z:"bar" AND ap:"foo"` (which should be the same query) would be
  converted into `z:"bar" OR x:"foo" OR y:"foo"`.
- In the above example, the `OR` is coming from the access point
  definition (or the default).  Also note the lack of parentheses.
- This changes the array to a `MultiTerm` Lucene object, which makes
  `z:"bar" AND ap:"foo"` convert to `z:"bar" AND (x:"foo" OR y:"foo")`,
  which is the intended behaviour.  Note the added parentheses.

Also fix a coding / typo issue in `LuceneSyntaxParserContext`, where a non-exception class was being `throw`n.
