### PR TITLE
Rwahs 626/search context is too sticky

### DIFF
--- a/app/models/ca_search_forms.php
+++ b/app/models/ca_search_forms.php
@@ -996,6 +996,44 @@ class ca_search_forms extends BundlableLabelableBaseModelWithAttributes {
 			);
 		}
 
+		// Hidden Field
+		$va_additional_settings = array(
+			'hidden_field_name' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_FIELD,
+				'width' => 25, 'height' => 1,
+				'takesLocale' => false,
+				'required' => true,
+				'label' => _t('Field Name'),
+				'description' => _t('Name of the hidden input field. For example <em>ca_objects.type_id</em>.'),
+			),
+			'hidden_field_value' => array(
+				'formatType' => FT_TEXT,
+				'displayType' => DT_FIELD,
+				'width' => 25, 'height' => 1,
+				'takesLocale' => false,
+				'requireValue' => true,
+				'label' => _t('Value'),
+				'description' => _t('Value of the hidden input field.')
+			)
+		);
+		$t_placement->setSettingDefinitionsForPlacement($va_additional_settings);
+		$vs_bundle = 'hidden_field';
+		$vs_display = "<div id='searchFormEditor_$vs_bundle'><span class='bundleDisplayEditorPlacementListItemTitle'>"._t('Custom').'</span> '.($vs_label = _t('Hidden Field'))."</div>";
+		$va_available_bundles[strip_tags($vs_display)][$vs_bundle] = array(
+			'bundle' => $vs_bundle,
+			'label' => $vs_label,
+			'display' => $vs_display,
+			'description' => $vs_description = _t('Provides a hidden search field on the search form.'),
+			'settingsForm' => $t_placement->getHTMLSettingForm(array('id' => $vs_bundle.'_0')),
+			'settings' => $va_additional_settings
+		);
+
+		TooltipManager::add(
+			"#searchFormEditor_$vs_bundle",
+			"<h2>{$vs_label}</h2>{$vs_description}"
+		);
+
 		ksort($va_available_bundles);
 
 		$va_sorted_bundles = array();
@@ -1145,6 +1183,22 @@ class ca_search_forms extends BundlableLabelableBaseModelWithAttributes {
 						'name' => $va_element['bundle_name']
 					);
 					continue(2);
+				case 'hidden_field':
+					if (!$vs_field_label) { $vs_field_label = ''; }
+					if(isset($va_element['settings']['hidden_field_name']) && isset($va_element['settings']['hidden_field_value'])){
+						$vs_name = strip_tags($va_element['settings']['hidden_field_name']);
+						$vs_value = strip_tags($va_element['settings']['hidden_field_value']);
+						$va_output[] = array(
+							'element' => caHTMLHiddenInput(
+								$vs_name, array(
+									'value' => $vs_value,
+								)
+							),
+							'label' => $vs_field_label,
+							'name' => $va_element['bundle_name']
+						);
+					}
+					continue(2);
 			}
 
 			$va_tmp = explode('.', $vs_field = $va_element['bundle_name']);
@@ -1276,6 +1330,8 @@ class ca_search_forms extends BundlableLabelableBaseModelWithAttributes {
 						$va_elements[] = $va_tmp[0].'.'.$va_tmp[1].'.'.$va_element_info['element_code'];
 					}
 				}
+			} elseif ($va_placement['bundle_name'] === 'hidden_field') {
+				$va_elements[] = $va_placement['settings']['hidden_field_name'];
 			} else {
 				$va_elements[] = $va_placement['bundle_name'];
 			}

--- a/app/models/ca_search_forms.php
+++ b/app/models/ca_search_forms.php
@@ -1188,15 +1188,16 @@ class ca_search_forms extends BundlableLabelableBaseModelWithAttributes {
 					if(isset($va_element['settings']['hidden_field_name']) && isset($va_element['settings']['hidden_field_value'])){
 						$vs_name = strip_tags($va_element['settings']['hidden_field_name']);
 						$vs_value = strip_tags($va_element['settings']['hidden_field_value']);
-						$va_output[] = array(
-							'element' => caHTMLHiddenInput(
-								$vs_name, array(
-									'value' => $vs_value,
-								)
-							),
-							'label' => $vs_field_label,
-							'name' => $va_element['bundle_name']
-						);
+						$va_output[] =
+							array(
+								'element' => caHTMLHiddenInput(
+									$vs_name, array(
+										'value' => $vs_value,
+									)
+								),
+								'label' => $vs_field_label,
+								'name' => $va_element['bundle_name']
+							);
 					}
 					continue(2);
 			}

--- a/app/plugins/rwahsNavigation/rwahsNavigationPlugin.php
+++ b/app/plugins/rwahsNavigation/rwahsNavigationPlugin.php
@@ -135,6 +135,7 @@ class rwahsNavigationPlugin extends BaseApplicationPlugin {
     private function _getCustomSearchMenuItems() {
         $va_custom_items = array();
         $va_shortcuts = $this->opo_config->get('search_menu_shortcuts');
+        $vs_root = 'string:' . caGetListRootID('object_types');
         if (is_array($va_shortcuts)) {
             foreach ($va_shortcuts as $vs_key => $va_shortcut) {
                 if (!isset($va_shortcut['type_code']) || !isset($va_shortcut['form_code']) || !isset($va_shortcut['display_code'])) {
@@ -183,7 +184,7 @@ class rwahsNavigationPlugin extends BaseApplicationPlugin {
                         'action' => 'Index'
                     ),
                     'parameters' => array(
-                        'type_id' => 'string:' . $vo_type->getPrimaryKey(),
+                        'type_id' => $vs_root,
                         'form_id' => 'string:' . $vn_form_id,
                         'display_id' => 'string:' . $vn_bundle_display_id,
                         'reset' => 'preference:persistent_search'
@@ -203,7 +204,7 @@ class rwahsNavigationPlugin extends BaseApplicationPlugin {
             ),
             'parameters' => array(
                 'reset' => 'preference:persistent_search',
-                'type_id' => 'string:' . caGetListRootID('object_types')
+                'type_id' => $vs_root
             )
         );
         $va_custom_items['object_browse'] = array(

--- a/tests/plugins/rwahsNavigation/RwahsNavigationPluginIntegrationTest.php
+++ b/tests/plugins/rwahsNavigation/RwahsNavigationPluginIntegrationTest.php
@@ -256,7 +256,7 @@ class RwahsNavigationPluginIntegrationTest extends AbstractPluginIntegrationTest
 		);
 		$this->assertEquals(
 			array(
-				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type1')->getPrimaryKey(),
+				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type1')->getHierarchyRootID(),
 				'form_id' => 'string:' . $this->_retrieveCreatedInstance('ca_search_forms', 'type1_search')->getPrimaryKey(),
 				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey(),
 				'reset' => 'preference:persistent_search'
@@ -290,7 +290,7 @@ class RwahsNavigationPluginIntegrationTest extends AbstractPluginIntegrationTest
 		);
 		$this->assertEquals(
 			array(
-				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type2')->getPrimaryKey(),
+				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type2')->getHierarchyRootID(),
 				'form_id' => 'string:' . $this->_retrieveCreatedInstance('ca_search_forms', 'type2_search')->getPrimaryKey(),
 				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey(),
 				'reset' => 'preference:persistent_search'
@@ -324,7 +324,7 @@ class RwahsNavigationPluginIntegrationTest extends AbstractPluginIntegrationTest
 		);
 		$this->assertEquals(
 			array(
-				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type3')->getPrimaryKey(),
+				'type_id' => 'string:' . $this->_retrieveCreatedInstance('ca_list_items', 'type3')->getHierarchyRootID(),
 				'form_id' => 'string:' . $this->_retrieveCreatedInstance('ca_search_forms', 'type3_search')->getPrimaryKey(),
 				'display_id' => 'string:' . $this->_retrieveCreatedInstance('ca_bundle_displays', 'result_display')->getPrimaryKey(),
 				'reset' => 'preference:persistent_search'


### PR DESCRIPTION
*Use the root object type for all searches
- Previously searches / browses were context sensitive to the last search performed
- This resets the search context to include all object types
  - Add hidden field advanced search form bundle
- Previously search forms could not be tied to a particular subset of results
- Now you can add a hidden field such as `<input type="hidden" name="ca_objects.type_id" value="artwork"/>`
