### PR TITLE
Backport fix for and search from upstream

### DIFF
--- a/app/lib/core/Plugins/SearchEngine/SqlSearch.php
+++ b/app/lib/core/Plugins/SearchEngine/SqlSearch.php
@@ -814,12 +814,6 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 								$qr_res = $this->opo_db->query($vs_sql, $vs_word, (int)$pn_subject_tablenum);
 								
 								$qr_count = $this->opo_db->query("SELECT count(*) c FROM {$vs_temp_table}");
-								if (!$qr_count->nextRow() || !(int)$qr_count->get('c')) { 
-									foreach($va_temp_tables as $vs_temp_table) {
-										$this->_dropTempTable($vs_temp_table);
-									}
-									break(2); 
-								}
 								
 								$va_temp_tables[] = $vs_temp_table;	
 							}


### PR DESCRIPTION
Includes #51 and that should be merged first.

This PR backports the fix from PROV-1846 into master-fix (the fix was only made on develop).

As a result `AND` no longer turns into `OR`

## Before
![toomanymoore](https://cloud.githubusercontent.com/assets/12571/20910614/887e7344-bb9d-11e6-9973-9588eb1ab18f.png)

## After
![nomoore](https://cloud.githubusercontent.com/assets/12571/20910567/45868ebe-bb9d-11e6-8cbd-2598a62d4a09.png)
